### PR TITLE
Bump fetch to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-stew": "^0.2.1",
     "broccoli-templater": "0.0.2",
-    "whatwg-fetch": "^0.7.0"
+    "whatwg-fetch": "^0.9.0"
   }
 }


### PR DESCRIPTION
For some reason, npm installed 0.7.0 (I assume "^0.7.0" should install 0.9.0 too?), which failed my code because i used `response.ok`... It works now with 0.9.0, I bump here so I don't have to update all my package.json files in the future :)