### PR TITLE
Renamed deprecated `ember install:addon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HTML5 [fetch](https://fetch.spec.whatwg.org) polyfill from [github](https://gith
 
 ## Installation
 
-* `ember install:addon ember-fetch`
+* `ember install ember-fetch`
 
 ## Usage
 


### PR DESCRIPTION
Renamed deprecated `ember install:addon` to `ember install`. This feature has been deprecated since Ember CLI v0.2.3, for more information see the [release notes](https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#023).