### PR TITLE
Allow automatic "waiting" in tests.

### DIFF
--- a/assets/browser-fetch.js.t
+++ b/assets/browser-fetch.js.t
@@ -14,7 +14,21 @@
 
     <%= moduleBody %>
 
-    self['default'] = self.fetch;
+    var pending = 0;
+    if (Ember.Test) {
+      Ember.Test.registerWaiter(function() { return pending === 0; });
+    }
+
+    function decrement(result) {
+      pending--;
+      return result;
+    }
+
+    self['default'] = function() {
+      pending++;
+
+      return self.fetch.apply(self, arguments).then(decrement, decrement);
+    };
     self['Headers'] = self.Headers;
     self['Request'] = self.Request;
     self['Response'] = self.Response;


### PR DESCRIPTION
This has been fundamentally supported when using $.ajax based requests for quite some time (since at least Ember 1.8ish).

This change brings testing parity to ember-fetch...