### PR TITLE
Empty response should yield Promise not empty object

### DIFF
--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -117,9 +117,11 @@ export function mungOptionsForFetch(_options, adapter) {
  */
 export function determineBodyPromise(response) {
   let bodyPromise;
-  const contentLength = response.headers.get('content-length');
 
-  if (contentLength && Number(contentLength)) {
+  // Content-Length is returned as a string or null, so we convert to a number.
+  const contentLength = Number(response.headers.get('content-length'));
+
+  if (contentLength > 0) {
     bodyPromise = response.json();
   } else {
     bodyPromise = RSVP.Promise.resolve({});

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -133,7 +133,12 @@ export default Ember.Mixin.create({
         if (response.ok) {
           // We want to check that there is a body in the response, otherwise JSON.parse will throw an error.
           // Instead, we'll let Ember Data handle an empty response.
-          const bodyPromise = response.headers.get('content-length') ? response.json() : {};
+          let bodyPromise;
+          if (response.headers.get('content-length')) {
+            bodyPromise = response.json();
+          } else {
+            bodyPromise = new RSVP.Promise((resolve) => resolve({}));
+          }
           return this.ajaxSuccess(response, bodyPromise, requestData);
         }
         throw this.ajaxError(null, response, requestData);

--- a/addon/mixins/adapter-fetch.js
+++ b/addon/mixins/adapter-fetch.js
@@ -119,7 +119,7 @@ export function determineBodyPromise(response) {
   let bodyPromise;
   const contentLength = response.headers.get('content-length');
 
-  if (contentLength && parseInt(contentLength)) {
+  if (contentLength && Number(contentLength)) {
     bodyPromise = response.json();
   } else {
     bodyPromise = RSVP.Promise.resolve({});

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -200,7 +200,6 @@ test('determineBodyResponse returns the body when it is present', function(asser
 test('determineBodyResponse returns an empty object when the body is not present', function(assert) {
   assert.expect(1);
 
-  const done = assert.async();
   const response = new Response('',
     {
       status: 200,
@@ -211,8 +210,7 @@ test('determineBodyResponse returns an empty object when the body is not present
   );
   const bodyPromise = determineBodyPromise(response);
 
-  bodyPromise.then((body) => {
+  return bodyPromise.then((body) => {
     assert.deepEqual(body, {});
-    done();
   });
 });

--- a/tests/unit/mixins/adapter-fetch-test.js
+++ b/tests/unit/mixins/adapter-fetch-test.js
@@ -1,14 +1,18 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import { module, test } from 'qunit';
-import { Headers } from 'fetch';
+import {
+  Headers,
+  Response
+} from 'fetch';
 import AdapterFetchMixin, {
   mungOptionsForFetch,
   headersToObject,
-  serialiazeQueryParams
+  serialiazeQueryParams,
+  determineBodyPromise
 } from 'ember-fetch/mixins/adapter-fetch';
-const { JSONAPIAdapter } = DS;
 
+const { JSONAPIAdapter } = DS;
 
 module('Unit | Mixin | adapter-fetch', {
   beforeEach() {
@@ -171,4 +175,44 @@ test('serialiazeQueryParams turns deeply nested objects into queryParams like $.
   const queryParamString = serialiazeQueryParams(body);
 
   assert.equal(queryParamString, 'a=1&b=2&c%5Bd%5D=3&c%5Be%5D%5Bf%5D=4&c%5Bg%5D%5B%5D=5&c%5Bg%5D%5B%5D=6&c%5Bg%5D%5B%5D=7');
+});
+
+test('determineBodyResponse returns the body when it is present', function(assert) {
+  assert.expect(1);
+
+  const done = assert.async();
+  const response = new Response('{"data": "foo"}',
+    {
+      status: 200,
+      headers: new Headers({
+        'Content-Length': 15
+      })
+    }
+  );
+  const bodyPromise = determineBodyPromise(response);
+
+  bodyPromise.then((body) => {
+    assert.deepEqual(body, {data: 'foo'});
+    done();
+  });
+});
+
+test('determineBodyResponse returns an empty object when the body is not present', function(assert) {
+  assert.expect(1);
+
+  const done = assert.async();
+  const response = new Response('',
+    {
+      status: 200,
+      headers: new Headers({
+        'Content-Length': 0
+      })
+    }
+  );
+  const bodyPromise = determineBodyPromise(response);
+
+  bodyPromise.then((body) => {
+    assert.deepEqual(body, {});
+    done();
+  });
 });


### PR DESCRIPTION
Without this change, the code in `ajaxSuccess` will fail:

```
ajaxSuccess(response, bodyPromise, requestData) {
    const headersObject = headersToObject(response.headers);

    return bodyPromise.then((body) => {   // {} has no `then`
```

@stefanpenner @cibernox 